### PR TITLE
Preemptive authentication for PropFind

### DIFF
--- a/milton-client/src/main/java/io/milton/httpclient/Host.java
+++ b/milton-client/src/main/java/io/milton/httpclient/Host.java
@@ -625,7 +625,7 @@ public class Host extends Folder {
                     return response.getStatusLine().getStatusCode();
                 }
             };
-            Integer res = client.execute(m, respHandler);
+            Integer res = client.execute(m, respHandler, newContext());
 
             Utils.processResultCode(res, url);
             return responses;


### PR DESCRIPTION
It looks like PropFind was missed when preemptive authentication was implemented.
