### PR TITLE
Fixes broken UNLOCK method

### DIFF
--- a/milton-client/src/main/java/io/milton/httpclient/PropFindResponse.java
+++ b/milton-client/src/main/java/io/milton/httpclient/PropFindResponse.java
@@ -68,11 +68,7 @@ public class PropFindResponse {
                         owner = RespUtils.asString(elActiveLock, "owner");
                         Element elToken = elActiveLock.getChild("locktoken", RespUtils.NS_DAV);
                         if (elToken != null) {
-                            String t = RespUtils.asString(elToken, "href");
-                            if (t != null && t.contains(":")) {
-                                t = t.substring(t.indexOf(":"));
-                            }
-                            token = t;
+                            token = RespUtils.asString(elToken, "href");
                         } else {
                             token = null;
                         }

--- a/milton-client/src/main/java/io/milton/httpclient/UnLockMethod.java
+++ b/milton-client/src/main/java/io/milton/httpclient/UnLockMethod.java
@@ -34,7 +34,7 @@ public class UnLockMethod extends HttpRequestBase {
     public UnLockMethod( String uri, String lockToken ) throws URISyntaxException {
         setURI(new URI(uri));
 		this.lockToken = lockToken;
-		addHeader("Lock-Token", lockToken);
+		addHeader("Lock-Token", String.format("<%s>", lockToken));
     }
 
     @Override


### PR DESCRIPTION
As far as I understand from the specs, lock token URI (which is often "opaquelocktoken" in many cases) is a part of lock token and should be provided to UNLOCK method along with the token. Milton tears it off and thus UNLOCK doesn't work with e.g. Apache (although seems to work with Milton server).

This change keeps the contents of href tag as is. Besides, it wraps token with  <> in Lock-Token header (which seem to be necessary)
See http://www.webdav.org/specs/rfc4918.html#METHOD_UNLOCK
