### PR TITLE
Derive scheduling collection name

### DIFF
--- a/milton-api/src/main/java/io/milton/principal/CalDavSchedulingPrincipal.java
+++ b/milton-api/src/main/java/io/milton/principal/CalDavSchedulingPrincipal.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.milton.principal;
+
+/**
+ * CalDAV principal that has a scheduling inbox and outbox
+ * @author dachristensen
+ */
+public interface CalDavSchedulingPrincipal extends CalDavPrincipal {
+    String getSchedulingInboxUrl();
+    String getSchedulingOutboxUrl();
+}

--- a/milton-api/src/main/java/io/milton/resource/SchedulingHomeResource.java
+++ b/milton-api/src/main/java/io/milton/resource/SchedulingHomeResource.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.milton.resource;
+
+/**
+ * A type of Resource which contains the scheduling inbox and outbox
+ *  and can return their names.
+ * <P/>
+ * @author dachristensen
+ */
+public interface  SchedulingHomeResource extends CollectionResource {
+    String getInboxName();
+    String getOutboxName();
+}

--- a/milton-server-ce/src/main/java/io/milton/http/annotated/AnnoCalendarHomeResource.java
+++ b/milton-server-ce/src/main/java/io/milton/http/annotated/AnnoCalendarHomeResource.java
@@ -22,6 +22,8 @@ import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.resource.Resource;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.milton.resource.SchedulingHomeResource;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -29,7 +31,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author brad
  */
-public class AnnoCalendarHomeResource extends AnnoCollectionResource {
+public class AnnoCalendarHomeResource extends AnnoCollectionResource implements SchedulingHomeResource {
 
 	private static final org.slf4j.Logger log = LoggerFactory.getLogger(AnnoCalendarHomeResource.class);
 
@@ -66,7 +68,13 @@ public class AnnoCalendarHomeResource extends AnnoCollectionResource {
 		outboxResource = new SchedulingOutboxResource(principal, calendarSearchService, calendarSearchService.getSchedulingOutboxColName());
 	}
 
-	
-	
-	
+    @Override
+    public String getInboxName() {
+        return calendarSearchService.getSchedulingInboxColName();
+    }
+
+    @Override
+    public String getOutboxName() {
+        return calendarSearchService.getSchedulingOutboxColName();
+    }
 }

--- a/milton-server-ce/src/main/java/io/milton/http/annotated/AnnoPrincipalResource.java
+++ b/milton-server-ce/src/main/java/io/milton/http/annotated/AnnoPrincipalResource.java
@@ -23,12 +23,11 @@ import io.milton.http.exceptions.BadRequestException;
 import io.milton.http.exceptions.NotAuthorizedException;
 import io.milton.http.values.HrefList;
 import io.milton.http.values.SupportedCalendarComponentListsSet;
-import io.milton.principal.CalDavPrincipal;
-import io.milton.principal.CardDavPrincipal;
-import io.milton.principal.DiscretePrincipal;
-import io.milton.principal.HrefPrincipleId;
+import io.milton.principal.*;
 import io.milton.resource.Resource;
 import java.util.List;
+
+import io.milton.resource.SchedulingHomeResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +35,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author brad
  */
-public class AnnoPrincipalResource extends AnnoCollectionResource implements DiscretePrincipal, CalDavPrincipal, CardDavPrincipal {
+public class AnnoPrincipalResource extends AnnoCollectionResource implements DiscretePrincipal, CalDavSchedulingPrincipal, CardDavPrincipal {
 
 	private static final Logger log = LoggerFactory.getLogger(AnnoPrincipalResource.class);
 	private String email;
@@ -163,4 +162,40 @@ public class AnnoPrincipalResource extends AnnoCollectionResource implements Dis
 		}
 		return cuType;
 	}
+
+    protected SchedulingHomeResource getSchedulingHome() {
+        SchedulingHomeResource schedulingHomeResource = null;
+        try
+        {
+            for (Resource r : getChildren()) {
+                if (r instanceof SchedulingHomeResource) {
+                    schedulingHomeResource = (SchedulingHomeResource)r;
+                    break;
+                }
+            }
+        } catch (BadRequestException e) {
+            throw new RuntimeException(e);
+        } catch (NotAuthorizedException e) {
+            throw new RuntimeException(e);
+        }
+        return schedulingHomeResource;
+    }
+
+    @Override
+    public String getSchedulingInboxUrl() {
+        String inboxUrl = null;
+        SchedulingHomeResource home = getSchedulingHome();
+        if(home != null)
+            inboxUrl = getPrincipalURL() + home.getName() + "/" + home.getInboxName() + "/";
+        return inboxUrl;
+    }
+
+    @Override
+    public String getSchedulingOutboxUrl() {
+        String inboxUrl = null;
+        SchedulingHomeResource home = getSchedulingHome();
+        if(home != null)
+            inboxUrl = getPrincipalURL() + home.getName() + "/" + home.getOutboxName() + "/";
+        return inboxUrl;
+    }
 }

--- a/milton-server-ce/src/main/java/io/milton/http/webdav/WebDavResourceTypeHelper.java
+++ b/milton-server-ce/src/main/java/io/milton/http/webdav/WebDavResourceTypeHelper.java
@@ -19,6 +19,8 @@
 
 package io.milton.http.webdav;
 
+import io.milton.principal.CalDavPrincipal;
+import io.milton.principal.DiscretePrincipal;
 import io.milton.resource.CollectionResource;
 import io.milton.resource.LockableResource;
 import io.milton.resource.Resource;
@@ -39,14 +41,20 @@ public class WebDavResourceTypeHelper implements ResourceTypeHelper {
 
 	@Override
     public List<QName> getResourceTypes( Resource r ) {
-        if( r instanceof CollectionResource ) {
-            ArrayList<QName> list = new ArrayList<QName>();
-            QName qn = new QName( WebDavProtocol.NS_DAV.getName(), "collection" );
+        ArrayList<QName> list = null;
+        if (r instanceof DiscretePrincipal) {
+            QName qn = new QName( WebDavProtocol.NS_DAV.getName() , "principal");
+            if(list == null)
+                list = new ArrayList<QName>();
             list.add( qn );
-            return list;
-        } else {
-            return null;
         }
+        if( r instanceof CollectionResource ) {
+            QName qn = new QName( WebDavProtocol.NS_DAV.getName(), "collection" );
+            if(list == null)
+                list = new ArrayList<QName>();
+            list.add( qn );
+        }
+        return list;
     }
 
     //Need to create a ArrayList as Arrays.asList returns a fixed length list which

--- a/milton-server-ent/src/main/java/io/milton/http/caldav/CalDavProtocol.java
+++ b/milton-server-ent/src/main/java/io/milton/http/caldav/CalDavProtocol.java
@@ -4,6 +4,7 @@
  */
 package io.milton.http.caldav;
 
+import io.milton.principal.CalDavSchedulingPrincipal;
 import io.milton.webdav.utils.CalendarDataProperty;
 import io.milton.http.values.SupportedCalendarComponentList;
 import io.milton.principal.CalDavPrincipal;
@@ -303,13 +304,17 @@ public class CalDavProtocol implements HttpExtension, PropertySource, WellKnownH
 
         @Override
         public WrappedHref getValue(PropFindableResource res) {
-            if (res instanceof CalDavPrincipal) {
+            WrappedHref href = null;
+            if (res instanceof CalDavSchedulingPrincipal) {
+                String url = ((CalDavSchedulingPrincipal) res).getSchedulingInboxUrl();
+                href = new WrappedHref(url);
+            }
+            if(href == null && (res instanceof CalDavPrincipal)) {
                 CalDavPrincipal p = (CalDavPrincipal) res;
                 String s = p.getPrincipalURL() + calendarSearchService.getSchedulingColName() + "/" + calendarSearchService.getSchedulingInboxColName() + "/";
-                return new WrappedHref(s);
-            } else {
-                return null;
+                href = new WrappedHref(s);
             }
+            return href;
         }
 
         @Override
@@ -332,14 +337,17 @@ public class CalDavProtocol implements HttpExtension, PropertySource, WellKnownH
 
         @Override
         public WrappedHref getValue(PropFindableResource res) {
-            if (res instanceof CalDavPrincipal) {
+            WrappedHref href = null;
+            if (res instanceof CalDavSchedulingPrincipal) {
+                String url = ((CalDavSchedulingPrincipal) res).getSchedulingOutboxUrl();
+                href = new WrappedHref(url);
+            }
+            if(href == null && (res instanceof CalDavPrincipal)) {
                 CalDavPrincipal p = (CalDavPrincipal) res;
                 String s = p.getPrincipalURL() + calendarSearchService.getSchedulingColName() + "/" + calendarSearchService.getSchedulingOutboxColName() + "/";
-                return new WrappedHref(s);
-            } else {
-                return null;
+                href = new WrappedHref(s);
             }
-
+            return href;
         }
 
         @Override


### PR DESCRIPTION
I made two changes here:
1. Any resource that implements DiscretePrincipal returns a DAV:resourcetype of DAV:principal.
2. Currently the scheduling collection name is hard-coded in the DefaultCalendarSearchService as "cals". The AnnoCalendarHomeResource automatically creates the scheduling inbox and outbox resources, but may not represent a resource with the name "cals". In this case, the CALDAV:schedule-inbox-URL and CALDAV:schedule-outbox-URL property on the principal resource is incorrect and leads to 404 errors when syncing with the Mac Calendar application.

I considered several alternatives for fixing this problem. My first thought was to just add an annotation to allow the implementer to override the name of the scheduling collection to match whatever they used for the calendars home collections. However, since the AnnoCalendarsHomeResource is responsible for automatically generating the inbox and outbox resources AND knows the name of the resource that it is wrapping, it seemed fitting that it should just return the correct value for the name of the scheduling collection.

I was concerned about preserving backwards compatibility, so I added new interfaces rather than adding properties/methods to existing ones. So, I created two new interfaces. CalDavSchedulingPrincipal is a CalDavPrincipal that additionally knows the scheduling inbox and outbox URL's. SchedulingHomeResource is a  type of resource that contains the inbox and outbox resources and can return their names for the purpose of calculating the URL's.

AnnoCalendarHomeResource now implements SchedulingHomeResource and currently returns the inbox and outbox name specified in the CalendarSearchService that it has a reference to. We might at some point want to still add annotations to allow the inbox/outbox names to be customized.

AnnoPrincipalResource now implements CalDavSchedulingPrincipal. It calculates the inbox/outbox URL's by searching through it's immediate children for a resource that implements the SchedulingHomeResource interface. It then take the principal URL for it's self and appends the name of the scheduling home resource followed by the name of the inbox/outbox as returned by the scheduling home resource.

Again, to preserve backwards compatibility I left the logic in place in CalDavProtocol.Schedule[Inbox|Outbox]Property#getValue() that derives the inbox/outbox name directly from the principal URL and calendar search service if the resource is not a CalDavSchedulingPrincipal or does not return a URL.
# Some oddities of this approach:
1. CalendarSearchService#getSchedulingColName() for annotated resources.
2. SchedulingHomeResource has no meaning for non-annotated resources. A non-annotated implementation must implement CalDavSchedulingPrincipal or CalendarSearchService to return inbox/outbox url's with a non-default scheduling collection name.
