### PR TITLE
expand principal search support

### DIFF
--- a/milton-api/src/main/java/io/milton/principal/PrincipalSearchCriteria.java
+++ b/milton-api/src/main/java/io/milton/principal/PrincipalSearchCriteria.java
@@ -8,10 +8,30 @@ import java.util.List;
  */
 public class PrincipalSearchCriteria {
 
-    public enum TestType {
+    public enum TestType
+    {
+        ANY("anyof"),
+        ALL("allof"),;
 
-        ANY,
-        ALL
+        private String code;
+
+        private TestType(String code)
+        {
+            this.code = code;
+        }
+
+        public static TestType fromCode( String code )
+        {
+           TestType testType = ALL;
+           if(code != null && code.equals(ANY.code))
+              testType = ANY;
+           return testType;
+        }
+
+        public String getCode()
+        {
+            return code;
+        }
     }
 
     public enum MatchType {

--- a/milton-server-ent/src/main/java/io/milton/ent/config/HttpManagerBuilderEnt.java
+++ b/milton-server-ent/src/main/java/io/milton/ent/config/HttpManagerBuilderEnt.java
@@ -386,5 +386,17 @@ public class HttpManagerBuilderEnt extends HttpManagerBuilder {
         this.calendarSearchService = calendarSearchService;
     }
 
-    
+   /**
+    * Search service used to satisfy principal property search reports. You can set this
+    *  to prevent the default search service from being created.
+    *
+    * @return Principal search service
+    */
+    public PrincipalSearchService getPrincipalSearchService() {
+       return principalSearchService;
+    }
+
+    public void setPrincipalSearchService(PrincipalSearchService principalSearchService) {
+       this.principalSearchService = principalSearchService;
+    }
 }


### PR DESCRIPTION
Set the principal search service on the HttpManagerBuilder. Parse the
principal search criteria from the principal-property-search XML
document.
