### PR TITLE
PROPPATCH sax handler fix

### DIFF
--- a/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
+++ b/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
@@ -87,6 +87,7 @@ public class PropPatchSaxHandler extends DefaultHandler {
 					}
 				}
 				sb = new StringBuilder();
+				inProp = false;
 			} else {
 				if (inProp) {
 					sb.append("</" + localName + ">");


### PR DESCRIPTION
For supporting custom properties. The prop endElement has to be flagged.
