### PR TITLE
Update source object after replaceContent

### DIFF
--- a/milton-server-ce/src/main/java/io/milton/http/annotated/AnnoFileResource.java
+++ b/milton-server-ce/src/main/java/io/milton/http/annotated/AnnoFileResource.java
@@ -33,7 +33,7 @@ public class AnnoFileResource extends AnnoResource implements GetableResource, R
 
 	@Override
 	public void replaceContent(InputStream in, Long length) throws BadRequestException, ConflictException, NotAuthorizedException {
-		annoFactory.putChildAnnotationHandler.replace(this, in, length);
+		source = annoFactory.putChildAnnotationHandler.replace(this, in, length);
 	}
 
 	@Override

--- a/milton-server-ce/src/main/java/io/milton/http/annotated/PutChildAnnotationHandler.java
+++ b/milton-server-ce/src/main/java/io/milton/http/annotated/PutChildAnnotationHandler.java
@@ -66,7 +66,7 @@ public class PutChildAnnotationHandler extends AbstractAnnotationHandler {
 		}
 	}
 
-	public void replace(AnnoFileResource fileRes, InputStream inputStream, Long length) throws ConflictException, NotAuthorizedException, BadRequestException {
+	public Object replace(AnnoFileResource fileRes, InputStream inputStream, Long length) throws ConflictException, NotAuthorizedException, BadRequestException {
 		log.trace("execute PUT (replace) method");
 		Object source = fileRes.getSource();
 		ControllerMethod cm = getBestMethod(source.getClass());
@@ -74,11 +74,11 @@ public class PutChildAnnotationHandler extends AbstractAnnotationHandler {
 			// ok, cant replace. Maybe we can delete and PUT?
 			String name = fileRes.getName();
 			annoResourceFactory.deleteAnnotationHandler.execute(fileRes);
-			execute(fileRes.getParent(), name, inputStream, length, null);
+			return execute(fileRes.getParent(), name, inputStream, length, null);
 
 		} else {
 			try {
-				invoke(cm, fileRes, inputStream, length, fileRes);
+                return invoke(cm, fileRes, inputStream, length, fileRes);
 			} catch (NotAuthorizedException e) {
 				throw e;
 			} catch (BadRequestException e) {


### PR DESCRIPTION
Update source object after replaceContent to resolve problem where ETag
is not calculated correctly after a put when source object is immutable
and must be replaced.
