### PR TITLE
Stop expansion when we run out of nested properties.

### DIFF
--- a/milton-server-ent/src/main/java/io/milton/http/caldav/ExpandPropertyReport.java
+++ b/milton-server-ent/src/main/java/io/milton/http/caldav/ExpandPropertyReport.java
@@ -268,10 +268,14 @@ public class ExpandPropertyReport implements Report {
 				if (val instanceof HrefList) {
 					HrefList hrefList = (HrefList) val;
 					Property nestedProp = prop.getNestedMap().get(name);
-					PropFindResponseList nestedList = toResponseList(host, hrefList, nestedProp);
-					replaceHrefs(host, nestedList, nestedProp);
-					r.getKnownProperties().remove(name);
-					r.getKnownProperties().put(name, new ValueAndType(nestedList, PropFindResponseList.class));
+					// Check for another level of nesting
+					if (nestedProp != null && nestedProp.getNested() != null && !nestedProp.getNested().isEmpty())
+					{
+						PropFindResponseList nestedList = toResponseList(host, hrefList, nestedProp);
+						replaceHrefs(host, nestedList, nestedProp);
+						r.getKnownProperties().remove(name);
+						r.getKnownProperties().put(name, new ValueAndType(nestedList, PropFindResponseList.class));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This patch prevents the over-expansion of HrefList properties once we have run out of nested properties to expand in the original request. I encountered this while expanding group members from the following expand-property report submitted by the Mac Calendar application:

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<A:expand-property xmlns:A="DAV:">
    <A:property name="expanded-group-member-set" namespace="http://calendarserver.org/ns/">
        <A:property name="displayname" namespace="DAV:"/>
        <A:property name="record-type" namespace="http://calendarserver.org/ns/"/>
        <A:property name="principal-URL" namespace="DAV:"/>
        <A:property name="last-name" namespace="http://calendarserver.org/ns/"/>
        <A:property name="calendar-user-address-set" namespace="urn:ietf:params:xml:ns:caldav"/>
        <A:property name="first-name" namespace="http://calendarserver.org/ns/"/>
        <A:property name="calendar-user-type" namespace="urn:ietf:params:xml:ns:caldav"/>
    </A:property>
</A:expand-property>
```

Since, the principal-URL and calendar-user-address-set are both HrefList properties, the current implementation was recursing to expand them. But since there were no nested properties to expand for each of these properties, they were being replaced either with garbage or nothing at all.
