### PR TITLE
principal-property-search use principal-URL as href

### DIFF
--- a/milton-server-ent/src/main/java/io/milton/http/acl/PrincipalPropertySearchReport.java
+++ b/milton-server-ent/src/main/java/io/milton/http/acl/PrincipalPropertySearchReport.java
@@ -133,11 +133,8 @@ public class PrincipalPropertySearchReport implements Report {
         } else {
             log.info("foundResources: null");
         }
-        String parentHref = HttpManager.request().getAbsolutePath();
-        parentHref = Utils.suffixSlash(parentHref);
         for (DiscretePrincipal dp : foundResources) {
-            String href = parentHref + dp.getName();
-
+            String href = dp.getPrincipalURL();
             List<PropFindResponse> resps = new ArrayList<PropFindResponse>();
             if (dp instanceof PropFindableResource) {
                 PropFindableResource pfr = (PropFindableResource) dp;


### PR DESCRIPTION
The PrincipalPropertySearchReport returns the wrong HREF for a principal when the principal resource does not "live" directly beneath the resource where the report was executed. In my case, the principal-collection-set is /principals but the principals urls are something like: /principals/users/{username}, /principals/groups/{groupname}, /principals/resources/{resource} or in normalized form /principals/.uids/{guid}. Using the principal URL should work for either case.
