### PR TITLE
PropPatchSaxHandler fixes

### DIFF
--- a/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
+++ b/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
@@ -22,93 +22,239 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Stack;
 import javax.xml.namespace.QName;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-public class PropPatchSaxHandler extends DefaultHandler {
-
+public class PropPatchSaxHandler extends DefaultHandler
+{
 	private final static Logger log = LoggerFactory.getLogger(PropPatchSaxHandler.class);
-	private final Stack<String> elementPath = new Stack<String>();
-	private Map<QName, String> attributesCurrent; // will switch between the following
+	private final static QName SET = new QName(WebDavProtocol.DAV_URI, "set");
+	private final static QName REMOVE = new QName(WebDavProtocol.DAV_URI, "remove");
+	private final static QName PROP = new QName(WebDavProtocol.DAV_URI, "prop");
+	private final Stack<StateHandler> handlers = new Stack<StateHandler>();
 	private final Map<QName, String> attributesSet = new LinkedHashMap<QName, String>();
 	private final Map<QName, String> attributesRemove = new LinkedHashMap<QName, String>();
-	private StringBuilder sb = new StringBuilder();
-	private boolean inProp;
 
 	@Override
-	public void startElement(String uri, String localName, String name, Attributes attributes) throws SAXException {
-		if (inProp) {
-			sb.append("<").append(localName).append(">");
-		}
-		if (elementPath.size() > 0) {
-			String elName = elementPath.peek();
-			if (attributesCurrent != null) {
-				if (elName.endsWith("prop")) {
-					inProp = true;
-				}
-			} else {
-				if (elName.endsWith("set")) {
-					attributesCurrent = attributesSet;
-				} else if (elName.endsWith("remove")) {
-					attributesCurrent = attributesRemove;
-				}
-			}
-
-		}
-		elementPath.push(localName);
+	public void startElement(String uri, String localName, String name, Attributes attributes) throws SAXException
+	{
+		QName qname = new QName(uri, localName);
+		StateHandler handler;
+		if (!handlers.isEmpty())
+			handler = handlers.peek().startChild(qname, attributes);
+		else
+			handler = new Root(attributesSet, attributesRemove);
+		handlers.push(handler);
 		super.startElement(uri, localName, name, attributes);
 	}
 
 	@Override
-	public void characters(char[] ch, int start, int length) throws SAXException {
-		if (inProp) {
-			sb.append(ch, start, length);
-		}
+	public void characters(char[] ch, int start, int length) throws SAXException
+	{
+		handlers.peek().characters(ch, start, length);
 	}
 
 	@Override
-	public void endElement(String uri, String localName, String name) throws SAXException {
-		elementPath.pop();
-		if (elementPath.size() > 0) {
-			if (elementPath.peek().endsWith("prop")) {
-				if (sb != null) {
-					String s = sb.toString().trim();
-					QName qname = new QName(uri, localName);
-					if (attributesCurrent != null) {
-						// will usually have this because of the set or remove element
-						attributesCurrent.put(qname, s);
-					} else {
-						// but for mkcalendar there's no set or remove element so default to set attributes
-						attributesSet.put(qname, s);
-					}
-				}
-				sb = new StringBuilder();
-				inProp = false;
-			} else {
-				if (inProp) {
-					sb.append("</").append(localName).append(">");
-				}
-
-				if (elementPath.peek().endsWith("set")) {
-					attributesCurrent = null;
-				} else if (elementPath.peek().endsWith("remove")) {
-					attributesCurrent = null;
-				}
-			}
-
-		}
-
+	public void endElement(String uri, String localName, String name) throws SAXException
+	{
+		QName qname = new QName(uri, localName);
+		StateHandler handler = handlers.pop();
+		handler.endSelf(qname);
 		super.endElement(uri, localName, name);
 	}
 
-	public Map<QName, String> getAttributesToSet() {
+	public Map<QName, String> getAttributesToSet()
+	{
 		return attributesSet;
 	}
 
-	public Map<QName, String> getAttributesToRemove() {
+	public Map<QName, String> getAttributesToRemove()
+	{
 		return attributesRemove;
+	}
+
+	/**
+	 * Abstract class to handle SAX events for the various states
+	 * that we expect to encounter while parsing a PROPATCH XML
+	 * document.
+	 */
+	private static abstract class StateHandler
+	{
+		public abstract StateHandler startChild(QName name, Attributes attributes)
+				throws SAXException;
+
+		public void endSelf(QName name)
+				throws SAXException
+		{
+		}
+
+		public void characters(char[] ch, int start, int length)
+				throws SAXException
+		{
+		}
+
+		private static StateHandler Ignore = new StateHandler()
+		{
+			@Override
+			public StateHandler startChild(QName name, Attributes attributes) throws SAXException
+			{
+				return this;
+			}
+		};
+	}
+
+	/**
+	 * State handler for the root element of a PROPPATCH request. This
+	 * expects to get either a "set" or "remove" element and ignores
+	 * any other content.
+	 */
+	private static class Root extends StateHandler
+	{
+		private final Map<QName, String> set;
+		private final Map<QName, String> remove;
+
+		private Root(Map<QName, String> set, Map<QName, String> remove)
+		{
+			this.set = set;
+			this.remove = remove;
+		}
+
+		@Override
+		public StateHandler startChild(QName name, Attributes attributes) throws SAXException
+		{
+			if (name.equals(SET))
+				return new Op(set);
+			if (name.equals(REMOVE))
+				return new Op(remove);
+			return StateHandler.Ignore;
+		}
+	}
+
+	/**
+	 * State handler for a "set" or "remove" child or a PROPPATCH request.
+	 * This expects to get a "prop" as a child element and ignores all
+	 * others.
+	 */
+	private static class Op extends StateHandler
+	{
+		private final Map<QName, String> values;
+
+		private Op(Map<QName, String> values)
+		{
+			this.values = values;
+		}
+
+		@Override
+		public StateHandler startChild(QName name, Attributes attributes) throws SAXException
+		{
+			if (name.equals(PROP))
+				return new Prop(values);
+			return StateHandler.Ignore;
+		}
+	}
+
+	/**
+	 * State handler for the "prop" element beneath a "set" or "remove" in
+	 * a PROPPATCH request. It treats children as individual attributes
+	 * to be recorded in it's value map.
+	 */
+	private static class Prop extends StateHandler
+	{
+		private final Map<QName, String> values;
+
+		private Prop(Map<QName, String> values)
+		{
+			this.values = values;
+		}
+
+		@Override
+		public StateHandler startChild(QName name, Attributes attributes) throws SAXException
+		{
+			return new Attribute(values);
+		}
+	}
+
+	/**
+	 * Attribute to be set or removed in a PROPPATCH request. It's content
+	 *  and any child elements will be stringified and added to either the
+	 *  set or remove attribute maps.
+	 */
+	private static class Attribute extends StateHandler
+	{
+		private final Map<QName, String> values;
+		private final Content content = new Content();
+
+		private Attribute(Map<QName, String> values)
+		{
+			this.values = values;
+		}
+
+		@Override
+		public StateHandler startChild(QName name, Attributes attributes) throws SAXException
+		{
+			content.startChild(name, attributes);
+			return content;
+		}
+
+		@Override
+		public void endSelf(QName name) throws SAXException
+		{
+			values.put(name, content.getValue().trim());
+		}
+
+		@Override
+		public void characters(char[] ch, int start, int length) throws SAXException
+		{
+			content.characters(ch, start, length);
+		}
+	}
+
+	/**
+	 * Attribute content. All character data and sub-elements are
+	 *  appended to a string buffer.
+	 */
+	private static class Content extends StateHandler
+	{
+		private final StringBuilder value = new StringBuilder();
+
+		@Override
+		public StateHandler startChild(QName name, Attributes attributes) throws SAXException
+		{
+			value.append("<").append(name.getLocalPart());
+			if(attributes != null)
+			{
+				for(int i = 0; i < attributes.getLength(); i++)
+				{
+					value.append(" ");
+					value.append(attributes.getLocalName(i));
+					value.append("=\"");
+					value.append(attributes.getValue(i));
+					value.append("\"");
+				}
+			}
+			value.append(">");
+			return this;
+		}
+
+		@Override
+		public void endSelf(QName name) throws SAXException
+		{
+			value.append("</").append(name.getLocalPart()).append(">");
+		}
+
+		@Override
+		public void characters(char[] ch, int start, int length) throws SAXException
+		{
+			value.append(new String(ch, start, length));
+		}
+
+		public String getValue()
+		{
+			return value.toString();
+		}
 	}
 }

--- a/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
+++ b/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
@@ -97,7 +97,7 @@ public class PropPatchSaxHandler extends DefaultHandler
 		{
 		}
 
-		private static StateHandler Ignore = new StateHandler()
+		public static StateHandler Ignore = new StateHandler()
 		{
 			@Override
 			public StateHandler startChild(QName name, Attributes attributes) throws SAXException

--- a/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
+++ b/milton-server-ce/src/main/java/io/milton/http/webdav/PropPatchSaxHandler.java
@@ -243,7 +243,14 @@ public class PropPatchSaxHandler extends DefaultHandler
 		@Override
 		public void endSelf(QName name) throws SAXException
 		{
-			value.append("</").append(name.getLocalPart()).append(">");
+			if(value.charAt(value.length() - 1) == '>')
+			{
+				value.insert(value.length() - 1, '/');
+			}
+			else
+			{
+				value.append("</").append(name.getLocalPart()).append(">");
+			}
 		}
 
 		@Override

--- a/milton-server-ce/src/test/java/io/milton/http/webdav/DefaultPropPatchParserTest.java
+++ b/milton-server-ce/src/test/java/io/milton/http/webdav/DefaultPropPatchParserTest.java
@@ -145,8 +145,8 @@ public class DefaultPropPatchParserTest extends TestCase {
         assertEquals("1001", fieldsToSet.get(calendarOrder));
         assertEquals(timezone, fieldsToSet.get(calendarTimezone));
         assertEquals("Untitled", fieldsToSet.get(displayName));
-        assertEquals("<opaque></opaque>", fieldsToSet.get(transparency));
-        assertEquals("<comp name=\"VEVENT\"></comp>", fieldsToSet.get(supportedComponentSet));
+        assertEquals("<opaque/>", fieldsToSet.get(transparency));
+        assertEquals("<comp name=\"VEVENT\"/>", fieldsToSet.get(supportedComponentSet));
 
         Set<QName> fieldsToRemove = result.getFieldsToRemove();
         assertEquals(0, fieldsToRemove.size());

--- a/milton-server-ce/src/test/java/io/milton/http/webdav/DefaultPropPatchParserTest.java
+++ b/milton-server-ce/src/test/java/io/milton/http/webdav/DefaultPropPatchParserTest.java
@@ -20,26 +20,19 @@
 
 package io.milton.http.webdav;
 
-import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Set;
+
 import junit.framework.TestCase;
+
+import javax.xml.namespace.QName;
 
 /**
  *
  * @author brad
  */
 public class DefaultPropPatchParserTest extends TestCase {
-	
-	private static final String XML_list_property = "<D:propertyupdate xmlns:D=\"DAV:\"  xmlns:Z=\"http://ns.example.com/standards/z39.50/\">\n" +
-		"<D:set>\n" +
-		"<D:prop>\n" +
-		"<Z:Authors>\n" +
-		"<Z:Author>Jim Whitehead</Z:Author>\n" +
-		"<Z:Author>Roy Fielding</Z:Author>\n" +
-		"</Z:Authors>\n" +
-		"</D:prop>\n" +
-		"</D:set>\n" +
-		"</D:propertyupdate>";
-	
 	public DefaultPropPatchParserTest(String testName) {
 		super(testName);
 	}
@@ -49,12 +42,113 @@ public class DefaultPropPatchParserTest extends TestCase {
 		super.setUp();
 	}
 
-	public void testGetRequestedFields() {
-		System.out.println(XML_list_property);
-		DefaultPropPatchParser parser = new DefaultPropPatchParser();
-		PropPatchParseResult result = parser.getRequestedFields(new ByteArrayInputStream(XML_list_property.getBytes()));
-		assertEquals(1, result.getFieldsToSet().size());
-		String s = result.getFieldsToSet().values().iterator().next();
-		System.out.println(s);
-	}
+    public void testMsOfficePropPatch() throws Exception
+    {
+        DefaultPropPatchParser parser = new DefaultPropPatchParser();
+        InputStream is = getClass().getResourceAsStream("/com/bradmcevoy/http/webdav/proppatch_request_msoffice.xml");
+        QName lastAccess = new QName("urn:schemas-microsoft-com:", "Win32LastAccessTime");
+        QName lastModified = new QName("urn:schemas-microsoft-com:", "Win32LastModifiedTime");
+        QName fileAttributes = new QName("urn:schemas-microsoft-com:", "Win32FileAttributes");
+
+        PropPatchParseResult result = parser.getRequestedFields(is);
+
+        Map<QName, String> fieldsToSet = result.getFieldsToSet();
+        assertEquals(3, fieldsToSet.size());
+        assertEquals("Wed, 10 Dec 2008 21:55:22 GMT", fieldsToSet.get(lastAccess));
+        assertEquals("Wed, 10 Dec 2008 21:55:22 GMT", fieldsToSet.get(lastModified));
+        assertEquals("00000020", fieldsToSet.get(fileAttributes));
+
+        Set<QName> fieldsToRemove = result.getFieldsToRemove();
+        assertEquals(0, fieldsToRemove.size());
+    }
+
+    public void testVistaPropPatch() throws Exception
+    {
+        DefaultPropPatchParser parser = new DefaultPropPatchParser();
+        InputStream is = getClass().getResourceAsStream("/com/bradmcevoy/http/webdav/proppatch_request_vista.http");
+        QName creationTime = new QName("urn:schemas-microsoft-com:", "Win32CreationTime");
+        QName lastAccess = new QName("urn:schemas-microsoft-com:", "Win32LastAccessTime");
+        QName lastModified = new QName("urn:schemas-microsoft-com:", "Win32LastModifiedTime");
+        QName fileAttributes = new QName("urn:schemas-microsoft-com:", "Win32FileAttributes");
+
+        PropPatchParseResult result = parser.getRequestedFields(is);
+
+        Map<QName, String> fieldsToSet = result.getFieldsToSet();
+        assertEquals(4, fieldsToSet.size());
+        assertEquals("Thu, 02 Jul 2009 11:28:59 GMT", fieldsToSet.get(creationTime));
+        assertEquals("Thu, 02 Jul 2009 11:28:59 GMT", fieldsToSet.get(lastAccess));
+        assertEquals("Thu, 02 Jul 2009 11:28:59 GMT", fieldsToSet.get(lastModified));
+        assertEquals("00000020", fieldsToSet.get(fileAttributes));
+
+        Set<QName> fieldsToRemove = result.getFieldsToRemove();
+        assertEquals(0, fieldsToRemove.size());
+    }
+
+    public void testSpecPropPatch() throws Exception
+    {
+        DefaultPropPatchParser parser = new DefaultPropPatchParser();
+        InputStream is = getClass().getResourceAsStream("/com/bradmcevoy/http/webdav/proppatch_request_spec.xml");
+        QName author1 = new QName("http://www.w3.com/standards/z39.50/", "Author1");
+        QName author2 = new QName("http://www.w3.com/standards/z39.50/", "Author2");
+        QName copyrightOwner = new QName("http://www.w3.com/standards/z39.50/", "Copyright-Owner");
+
+        PropPatchParseResult result = parser.getRequestedFields(is);
+
+        Map<QName, String> fieldsToSet = result.getFieldsToSet();
+        assertEquals(2, fieldsToSet.size());
+        assertEquals("Jim Whitehead", fieldsToSet.get(author1));
+        assertEquals("Roy Fielding", fieldsToSet.get(author2));
+
+        Set<QName> fieldsToRemove = result.getFieldsToRemove();
+        assertEquals(1, fieldsToRemove.size());
+        assertTrue(fieldsToRemove.contains(copyrightOwner));
+    }
+
+    public void testMkCalendar() throws Exception
+    {
+        DefaultPropPatchParser parser = new DefaultPropPatchParser();
+        InputStream is = getClass().getResourceAsStream("/com/bradmcevoy/http/webdav/mkcalendar_apple.xml");
+        QName calendarColor = new QName("http://apple.com/ns/ical/", "calendar-color");
+        QName calendarOrder = new QName("http://apple.com/ns/ical/", "calendar-order");
+        QName calendarTimezone = new QName("urn:ietf:params:xml:ns:caldav", "calendar-timezone");
+        QName displayName = new QName("DAV:", "displayname");
+        QName transparency = new QName("urn:ietf:params:xml:ns:caldav", "schedule-calendar-transp");
+        QName supportedComponentSet = new QName("urn:ietf:params:xml:ns:caldav", "supported-calendar-component-set");
+        String timezone = "BEGIN:VCALENDAR\r\n" +
+                "VERSION:2.0\r\n" +
+                "PRODID:-//Apple Inc.//Mac OS X 10.10//EN\r\n" +
+                "CALSCALE:GREGORIAN\r\n" +
+                "BEGIN:VTIMEZONE\r\n" +
+                "TZID:America/Denver\r\n" +
+                "BEGIN:DAYLIGHT\r\n" +
+                "TZOFFSETFROM:-0700\r\n" +
+                "RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU\r\n" +
+                "DTSTART:20070311T020000\r\n" +
+                "TZNAME:MDT\r\n" +
+                "TZOFFSETTO:-0600\r\n" +
+                "END:DAYLIGHT\r\n" +
+                "BEGIN:STANDARD\r\n" +
+                "TZOFFSETFROM:-0600\r\n" +
+                "RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU\r\n" +
+                "DTSTART:20071104T020000\r\n" +
+                "TZNAME:MST\r\n" +
+                "TZOFFSETTO:-0700\r\n" +
+                "END:STANDARD\r\n" +
+                "END:VTIMEZONE\r\n" +
+                "END:VCALENDAR";
+
+        PropPatchParseResult result = parser.getRequestedFields(is);
+
+        Map<QName, String> fieldsToSet = result.getFieldsToSet();
+        assertEquals(6, fieldsToSet.size());
+        assertEquals("#F64F00FF", fieldsToSet.get(calendarColor));
+        assertEquals("1001", fieldsToSet.get(calendarOrder));
+        assertEquals(timezone, fieldsToSet.get(calendarTimezone));
+        assertEquals("Untitled", fieldsToSet.get(displayName));
+        assertEquals("<opaque></opaque>", fieldsToSet.get(transparency));
+        assertEquals("<comp name=\"VEVENT\"></comp>", fieldsToSet.get(supportedComponentSet));
+
+        Set<QName> fieldsToRemove = result.getFieldsToRemove();
+        assertEquals(0, fieldsToRemove.size());
+    }
 }

--- a/milton-server-ce/src/test/resources/com/bradmcevoy/http/webdav/mkcalendar_apple.xml
+++ b/milton-server-ce/src/test/resources/com/bradmcevoy/http/webdav/mkcalendar_apple.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<B:mkcalendar xmlns:B="urn:ietf:params:xml:ns:caldav">
+    <A:set xmlns:A="DAV:">
+        <A:prop>
+            <B:supported-calendar-component-set>
+                <B:comp name="VEVENT"/>
+            </B:supported-calendar-component-set>
+            <E:calendar-order xmlns:E="http://apple.com/ns/ical/">1001</E:calendar-order>
+            <A:displayname>Untitled</A:displayname>
+            <E:calendar-color xmlns:E="http://apple.com/ns/ical/" symbolic-color="orange">#F64F00FF</E:calendar-color>
+            <B:calendar-timezone>BEGIN:VCALENDAR&#13;
+VERSION:2.0&#13;
+PRODID:-//Apple Inc.//Mac OS X 10.10//EN&#13;
+CALSCALE:GREGORIAN&#13;
+BEGIN:VTIMEZONE&#13;
+TZID:America/Denver&#13;
+BEGIN:DAYLIGHT&#13;
+TZOFFSETFROM:-0700&#13;
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU&#13;
+DTSTART:20070311T020000&#13;
+TZNAME:MDT&#13;
+TZOFFSETTO:-0600&#13;
+END:DAYLIGHT&#13;
+BEGIN:STANDARD&#13;
+TZOFFSETFROM:-0600&#13;
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU&#13;
+DTSTART:20071104T020000&#13;
+TZNAME:MST&#13;
+TZOFFSETTO:-0700&#13;
+END:STANDARD&#13;
+END:VTIMEZONE&#13;
+END:VCALENDAR&#13;
+            </B:calendar-timezone>
+            <B:schedule-calendar-transp>
+                <B:opaque/>
+            </B:schedule-calendar-transp>
+        </A:prop>
+    </A:set>
+</B:mkcalendar>


### PR DESCRIPTION
This fixes several problems that I was seeing in PROPPATCH and MKCALENDAR requests. First, I was seeing many properties come through with empty values. I think that this may have been a regression caused by the latest commit in this file. Next, child elements did not render their attributes to the value.

I chose to re-implement the SAX handler by using a stack of state handlers. Each state handler responds to a particular element in the parsing stack. I believe that this makes it much less confusing to track what content is expected and where it's value should be written.

I also added several unit tests for 3 proppatch XML documents that were already in src/test/resources/. In addition, I added a new test for a typical MKCALENDAR that comes from the apple Calendar client.