### PR TITLE
Handle relative multiget href

### DIFF
--- a/milton-server-ent/src/main/java/io/milton/http/report/AbstractMultiGetReport.java
+++ b/milton-server-ent/src/main/java/io/milton/http/report/AbstractMultiGetReport.java
@@ -60,10 +60,10 @@ public abstract class AbstractMultiGetReport implements QualifiedReport {
         List<PropFindResponse> respProps = new ArrayList<PropFindResponse>();
 
         for (String href : hrefs) {
-            String decodedHref = HttpManager.decodeUrl(href);
-            if(!decodedHref.startsWith("/")) {
-                decodedHref = Utils.suffixSlash(path) + decodedHref;
+            if(!href.startsWith("/")) {
+                href = Utils.suffixSlash(path) + href;
             }
+            String decodedHref = HttpManager.decodeUrl(href);
             Resource r = resourceFactory.getResource(host, decodedHref);
             if (r != null) {
                 if (r instanceof PropFindableResource) {

--- a/milton-server-ent/src/main/java/io/milton/http/report/AbstractMultiGetReport.java
+++ b/milton-server-ent/src/main/java/io/milton/http/report/AbstractMultiGetReport.java
@@ -5,6 +5,7 @@
 
 package io.milton.http.report;
 
+import io.milton.common.Utils;
 import io.milton.http.HttpManager;
 import io.milton.http.ResourceFactory;
 import io.milton.http.exceptions.BadRequestException;
@@ -60,14 +61,10 @@ public abstract class AbstractMultiGetReport implements QualifiedReport {
 
         for (String href : hrefs) {
             String decodedHref = HttpManager.decodeUrl(href);
-            if(!decodedHref.startsWith("/"))
-            {
-                String absolutePath = path;
-                if(!absolutePath.endsWith("/"))
-                    absolutePath += "/";
-                absolutePath += decodedHref;
-                decodedHref = absolutePath;
-            }            Resource r = resourceFactory.getResource(host, decodedHref);
+            if(!decodedHref.startsWith("/")) {
+                decodedHref = Utils.suffixSlash(path) + decodedHref;
+            }
+            Resource r = resourceFactory.getResource(host, decodedHref);
             if (r != null) {
                 if (r instanceof PropFindableResource) {
                     PropFindableResource pfr = (PropFindableResource) r;

--- a/milton-server-ent/src/main/java/io/milton/http/report/AbstractMultiGetReport.java
+++ b/milton-server-ent/src/main/java/io/milton/http/report/AbstractMultiGetReport.java
@@ -60,7 +60,14 @@ public abstract class AbstractMultiGetReport implements QualifiedReport {
 
         for (String href : hrefs) {
             String decodedHref = HttpManager.decodeUrl(href);
-            Resource r = resourceFactory.getResource(host, decodedHref);
+            if(!decodedHref.startsWith("/"))
+            {
+                String absolutePath = path;
+                if(!absolutePath.endsWith("/"))
+                    absolutePath += "/";
+                absolutePath += decodedHref;
+                decodedHref = absolutePath;
+            }            Resource r = resourceFactory.getResource(host, decodedHref);
             if (r != null) {
                 if (r instanceof PropFindableResource) {
                     PropFindableResource pfr = (PropFindableResource) r;


### PR DESCRIPTION
CalConnect Interop: BusyMac BusyCal client does a calendar-multiget with relative hrefs.