### PR TITLE
Fix double-slash bug in path parser

### DIFF
--- a/milton-api/src/main/java/io/milton/common/Path.java
+++ b/milton-api/src/main/java/io/milton/common/Path.java
@@ -56,10 +56,10 @@ public class Path implements Serializable {
             char c = s.charAt( i );
             switch( c ) {
                 case '/':
-                    if( sb == null ) {
+                    if( i == 0 ) {
                         parent = root;
                     } else {
-                        if( sb.length() > 0 ) {
+                        if( sb != null && sb.length() > 0 ) {
                             String ss = sb.toString();
                             if( parent != null ) parent = parent.child( ss );
                             else parent = new Path( null, ss );
@@ -75,12 +75,10 @@ public class Path implements Serializable {
                     sb.append( c );
             }
         }
-        if( sb != null ) {
-            if( sb.length() > 0 ) {
-                String ss = sb.toString();
-                if( parent != null ) parent = parent.child( ss );
-                else parent = new Path( null, ss );
-            }
+        if( sb != null && sb.length() > 0 ) {
+            String ss = sb.toString();
+            if( parent != null ) parent = parent.child( ss );
+            else parent = new Path( null, ss );
         }
 
         return parent;
@@ -121,7 +119,7 @@ public class Path implements Serializable {
     }
 
     /**
-     * 
+     *
      * @return - the first part of the path. ie a/b/c returns a
      */
     public String getFirst() {

--- a/milton-api/src/test/java/io/milton/common/PathTest.java
+++ b/milton-api/src/test/java/io/milton/common/PathTest.java
@@ -26,7 +26,7 @@ import junit.framework.TestCase;
  * @author brad
  */
 public class PathTest extends TestCase {
-    
+
     public PathTest(String testName) {
         super(testName);
     }
@@ -69,5 +69,10 @@ public class PathTest extends TestCase {
 
         Path path = Path.path("b/c");
         assertEquals(true,path.isRelative());
+    }
+
+    public void testDoubleSlash() {
+        Path p = Path.path("/a//b/c");
+        assertEquals("/a/b/c", p.toString());
     }
 }


### PR DESCRIPTION
The path parser mistakenly resets after a double slash, so paths
'/a/b' and '/z//a/b' are treated as the same path.  This patch
addresses this issue.