### PR TITLE
Issue #62 Packages scanning problem (reflection utils and package url protocol)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,10 @@ milton-mail-server/.settings/org.eclipse.wst.common.project.facet.core.xml
 milton-server-ce/.settings/org.eclipse.wst.common.project.facet.core.xml
 
 milton-server-ent/.settings/org.eclipse.wst.common.project.facet.core.xml
+
+*.iml
+.idea/
+*.ipr
+*.iws
+/out/
+.idea_modules/

--- a/milton-server-ce/src/main/java/io/milton/config/ReflectionUtils.java
+++ b/milton-server-ce/src/main/java/io/milton/config/ReflectionUtils.java
@@ -50,7 +50,8 @@ public class ReflectionUtils {
 
 		ClassLoader cld = Thread.currentThread().getContextClassLoader();
 
-		if (packageURL.getProtocol().equals("jar")) {
+		String packageProtocol = packageURL.getProtocol();
+		if (packageProtocol.equalsIgnoreCase("jar") || packageProtocol.equalsIgnoreCase("zip")) {
 			String jarFileName;
 			JarFile jf;
 			Enumeration<JarEntry> jarEntries;
@@ -58,7 +59,7 @@ public class ReflectionUtils {
 
 			// build jar file name, then loop through zipped entries
 			jarFileName = URLDecoder.decode(packageURL.getFile(), "UTF-8");
-			jarFileName = jarFileName.substring(5, jarFileName.indexOf("!"));
+			jarFileName = jarFileName.substring(0, jarFileName.indexOf("!"));
 			jf = new JarFile(jarFileName);
 			jarEntries = jf.entries();
 			while (jarEntries.hasMoreElements()) {

--- a/milton-server-ce/src/main/java/io/milton/config/ReflectionUtils.java
+++ b/milton-server-ce/src/main/java/io/milton/config/ReflectionUtils.java
@@ -43,6 +43,9 @@ public class ReflectionUtils {
 
 		String packagePath = packageName.replace(".", "/");
 		packageURL = classLoader.getResource(packagePath);
+		if (log.isTraceEnabled()) {
+			log.trace("Finding classes for package: '" + packageName + "'. packageUrl: " + packageURL);
+		}
 		if (packageURL == null) {
 			log.warn("getClassNamesFromPackage: No package could be found: " + packagePath + " from classloader: " + classLoader);
 			return classes;
@@ -62,6 +65,10 @@ public class ReflectionUtils {
 			jarFileName = jarFileName.substring(0, jarFileName.indexOf("!"));
 			jf = new JarFile(jarFileName);
 			jarEntries = jf.entries();
+			if (log.isTraceEnabled()) {
+				log.trace("Loading classes from JAR: url: " + packageURL + ", jarFileName: " + jarFileName);
+			}
+			int filesCountInJar = 0;
 			while (jarEntries.hasMoreElements()) {
 				entryName = jarEntries.nextElement().getName();
 				if (entryName.startsWith(packagePath) && entryName.length() > packagePath.length() + 5) {
@@ -73,8 +80,12 @@ public class ReflectionUtils {
 						classes.add(c);
 					}
 				}
+				++filesCountInJar;
 			}
 			jf.close();
+			if (log.isTraceEnabled()) {
+				log.trace("Files count in " + packageURL + ": " + filesCountInJar + ", count of class files in package " + packagePath + ":" + classes.size());
+			}
 
 			// loop through files in classpath
 		} else {


### PR DESCRIPTION
Hi,

I've prepared the fix for packages scanning problem withing jar files. I've seen two issues there:

a) the package protocol checking, the jar files have the 'zip' protocol so I'm checking that kind of protocol too
b) the jar file name is retrieved prom packageULR by getFile so the substring from 5 (in order to remove protocol) is unnecessary, the removing the classes on the end is enough 