### PR TITLE
Could io.milton:milton-proxy:3.1.1.413 drop off redundant dependencies?

### DIFF
--- a/milton-proxy/pom.xml
+++ b/milton-proxy/pom.xml
@@ -23,11 +23,35 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>milton-server-ce</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.inject</groupId>
+                    <artifactId>javax.inject</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.mail</groupId>
+                    <artifactId>javax.mail</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.mail</groupId>
+                    <artifactId>mail</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>milton-client</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Hi! I found the pom file of project **_io.milton:milton-proxy:3.1.1.413_** introduced **_45_** dependencies. However, among them, **_5_** libraries (**_11%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
xml-apis:xml-apis:jar:1.0.b2:compile
javax.mail:mail:jar:1.4:compile
javax.activation:activation:jar:1.1.1:compile
com.sun.mail:javax.mail:jar:1.6.2:compile
javax.inject:javax.inject:jar:1:compile
## Outdated dependencies
javax.inject:javax.inject:1 (**_5037_** days without maintenance)
com.sun.mail:javax.mail:1.6.2 (**_1795_** days without maintenance)
xml-apis:xml-apis:1.0.b2 (**_6458_** days without maintenance)
javax.activation:activation:1.1.1 (**_5027_** days without maintenance)

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.mail:mail:jar:1.4:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V1.0 (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) V1.0 cannot be used by the project with license Apache2), one of the redundant dependencies **_javax.activation:activation:jar:1.1.1:compile_** incorporates an incompatible license COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) VERSION 1.0) JAVABEANS(TM (COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) VERSION 1.0) JAVABEANS(TM cannot be used by the project with license Apache2). As such, I suggest a refactoring operation for **_io.milton:milton-proxy:3.1.1.413_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_io.milton:milton-proxy:3.1.1.413_**’s maven tests.

Best regards